### PR TITLE
Spike/suppress console message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # FSAStyles Changelog
 
+## 0.1.3-epimorphics
+
+- Suppressed the following console message `JS navigation elements not found`,
+  for more information see [GH-73](https://github.com/epimorphics/data-dot-food-browser/issues/73)
+
 ## 0.1.2-epimorphics
 
 - Fixed an issue where `yarn build` would fail due to a missing CSS file

--- a/component/navigation/navigation.js
+++ b/component/navigation/navigation.js
@@ -138,8 +138,9 @@ export function navigation () {
     siteElementArray.length <= 0
   ) {
     // See: https://github.com/epimorphics/data-dot-food-browser/issues/73
-    // TODO: Investigate why this happens and fix the root cause
-    // return console.log('JS navigation elements not found')
+    // TODO: Suppressed console message for the time being, investigate why this happens and fix the root cause
+    // console.log('JS navigation elements not found')
+    return
   }
 
   let secondLevelMenuArray = []

--- a/component/navigation/navigation.js
+++ b/component/navigation/navigation.js
@@ -137,7 +137,9 @@ export function navigation () {
     navigationElementArray.length <= 0 ||
     siteElementArray.length <= 0
   ) {
-    return console.log('JS navigation elements not found')
+    // See: https://github.com/epimorphics/data-dot-food-browser/issues/73
+    // TODO: Investigate why this happens and fix the root cause
+    // return console.log('JS navigation elements not found')
   }
 
   let secondLevelMenuArray = []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsastyles",
-  "version": "0.1.2+epimorphics",
+  "version": "0.1.3+epimorphics",
   "description": "npm package for using FSA styles",
   "author": "",
   "main": "index.js",


### PR DESCRIPTION
This PR suppresses the following console message `JS navigation elements not found`, for more information see https://github.com/epimorphics/data-dot-food-browser/issues/73